### PR TITLE
Fix syntax

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,3 @@
-{
+[
     { "keys": ["super+shift+f12"], "command": "rsync_ssh_sync" }
-}
+]


### PR DESCRIPTION
Should fix this error when trying to install on Linux:

> Error trying to parse file: Expected value in Packages/Rsync SSH/Default (Linux).sublime-keymap:2:5
