### PR TITLE
Error on non-latin console

### DIFF
--- a/rsync-ssh.py
+++ b/rsync-ssh.py
@@ -211,7 +211,7 @@ class Rsync(threading.Thread):
                 timeout=self.timeout,
                 stderr=subprocess.STDOUT
             ).decode('utf-8')
-            if not re.match("bash: type: rsync:", output):
+            if re.match("bash: type: rsync:", output):
                 message = "ERROR: Unable to locate rsync on "+self.remote.get("remote_host")
                 console_print(self.remote.get("remote_host"), self.local_path, message)
                 sublime.active_window().run_command("terminal_notifier", {


### PR DESCRIPTION
Console,  latin characters

``` bash
type rsync
> rsync is /usr/bin/rsync
```

Console, cyrillic characters

``` bash
type rsync
> rsync является /usr/bin/rsync
```

and «ascii» unicode error here.

Solution:
utf-8 decode, new regex

nonexistent command, for example

``` bash
type rsyncs

# Cyrillic
bash: type: rsyncs: не найден
# Latin
-bash: type: rsyncs: not found
```
