### PR TITLE
Force pseudo-tty allocation for SSH connection

### DIFF
--- a/rsync-ssh.py
+++ b/rsync-ssh.py
@@ -200,7 +200,7 @@ class Rsync(threading.Thread):
 
         # Check ssh connection, and verify that rsync exists in path on the remote host
         check_command = [
-            "ssh", "-q", "-p", str(self.remote.get("remote_port", "22")),
+            "ssh", "-q", "-tt", "-p", str(self.remote.get("remote_port", "22")),
             self.remote.get("remote_user")+"@"+self.remote.get("remote_host"),
             "LANG=C type rsync"
         ]


### PR DESCRIPTION
Without forced psuedo-tty allocation some servers return `stty: rsync is /usr/bin/rsync\nstandard input: Invalid argument\n`, which causes the regex to check for rsync to fail.

From the SSH man pages:

     -T      Disable pseudo-tty allocation.
     -t      Force pseudo-tty allocation.  This can be used to execute arbitrary screen-based programs on a remote machine, which can be very useful,
             e.g. when implementing menu services.  Multiple -t options force tty allocation, even if ssh has no local tty.

Before:
```
>>> check_command = ["ssh", "-q", "-p", "22", "user@myhost", "LANG=C type rsync"]
>>> subprocess.check_output(check_command, universal_newlines=True, timeout=200, stderr=subprocess.STDOUT)
'stty: rsync is /usr/bin/rsync\nstandard input: Invalid argument\n'
```

With `-T`:
```
>>> check_command = ["ssh", "-q", "-T", "-p", "22", "user@myhost", "LANG=C type rsync"]
>>> subprocess.check_output(check_command, universal_newlines=True, timeout=200, stderr=subprocess.STDOUT)
'rsync is /usr/bin/rsync\nstty: standard input: Invalid argument\n'
```

With `-tt`:
```
>>> check_command = ["ssh", "-q", "-tt", "-p", "22", "user@myhost", "LANG=C type rsync"]
>>> subprocess.check_output(check_command, universal_newlines=True, timeout=200, stderr=subprocess.STDOUT)
'rsync is /usr/bin/rsync\n'
```

I went with `-tt` because the output was the cleanest. I haven't yet had a chance to test this on a server that doesn't have the issue with the tty, but I don't think it'll mess up anything else.