### PR TITLE
If remote subdirectory is not in fullpath of local project path, just skip it

### DIFF
--- a/rsync-ssh.py
+++ b/rsync-ssh.py
@@ -155,6 +155,11 @@ class RsyncSSH(threading.Thread):
                     continue
 
                 if remote_key != ".":
+                    # Just continue if remote_key doesn't contain folder_path_basename, it means remote_key
+                    # doesn't correspond to local project dir
+                    if not folder_path_basename in remote_key:
+                        continue
+
                     # Get subfolder from remote key
                     # If remote key is relative also get the split prefix so we can get the container folder later
                     [split_prefix, subfolder] = str.split(remote_key, folder_path_basename, 2)


### PR DESCRIPTION
I have project that has 4 directories, but I synchronize only 2 of them. In such case algorithm throws an exception here:
                    # Get subfolder from remote key
                    # If remote key is relative also get the split prefix so we can get the container folder later
                    [split_prefix, subfolder] = str.split(remote_key, folder_path_basename, 2)

It is becuase my remote_key variable is a list of:
['/home/kkwiatkowski/SYNC1', 
'/home/kkwiatkowski/SYNC2']

And sublime.active_window().folders() returns list of:
['/home/kkwiatkowski/SYNC1',
 '/home/kkwiatkowski/NOSYNC1',
 '/home/kkwiatkowski/NOSYNC2', 
'/home/kkwiatkowski/NOSYNC3', 
'/home/kkwiatkowski/SYNC2']

so at some point algorithm calls str.split('/home/kkwiatkowski/SYNC1', 'NOSYNC2', 2) which returns list with one element, so ValueError is thrown.
