### PR TITLE
Split remote server answer by '\n' in ssh connection check

### DIFF
--- a/rsync-ssh.py
+++ b/rsync-ssh.py
@@ -272,7 +272,7 @@ class Rsync(threading.Thread):
             "LANG=C which rsync"
         ]
         try:
-            self.rsync_path = subprocess.check_output(check_command, universal_newlines=True, timeout=self.timeout, stderr=subprocess.STDOUT).rstrip()
+            self.rsync_path = subprocess.check_output(check_command, universal_newlines=True, timeout=self.timeout, stderr=subprocess.STDOUT).split('\n')[0].rstrip()
             if not self.rsync_path.endswith("/rsync"):
                 message = "ERROR: Unable to locate rsync on "+self.remote.get("remote_host")
                 console_print(self.remote.get("remote_host"), self.prefix, message)


### PR DESCRIPTION
Sometimes remote server returns more then one line when we check ssh connection:
	/usr/bin/rsync
	Killed by signal 1.
In this case we should split the answer by '\n' and take first item in list.
universal_newlines=True allows us to split by '\n' and split() always produce list, so we are safe even when recieving only path to rsync.