### PR TITLE
Making rsync command configurable

### DIFF
--- a/rsync_ssh.py
+++ b/rsync_ssh.py
@@ -108,6 +108,7 @@ class RsyncSshInitSettingsCommand(sublime_plugin.TextCommand):
                     "remote_user": current_user(),
                     "remote_pre_command": "",
                     "remote_post_command": "",
+                    "command": "rsync",
                     "enabled": 1,
                     "options": [],
                     "excludes": []
@@ -535,7 +536,7 @@ class Rsync(threading.Thread):
 
         # Build rsync command
         rsync_command = [
-            "rsync", "-v", "-zar",
+            rsync_ssh_settings(self.view).get("command", "rsync"), "-v", "-zar",
             "-e", " ".join(self.ssh_command_with_default_args())
         ]
 


### PR DESCRIPTION
Recent rsync updates. are incompatible in how ssh options are passed. This is a quick fix to make the path to rsync configurable and allow using an older version for the sublime text plugin