### PR TITLE
Implement an option to always sync the whole project when saving a file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ When you initialize your project via `Initialize Settings` the plugin will add t
             // To disable sync on save set 'sync_on_save' to false
             "sync_on_save": true,
 
+            // To always sync all files when saving (not just the saved file)
+            // set `sync_all_on_save` to true
+            "sync_all_on_save": true,
+
             // Rsync options
             "options":
             [

--- a/rsync_ssh.py
+++ b/rsync_ssh.py
@@ -90,6 +90,7 @@ class RsyncSshInitSettingsCommand(sublime_plugin.TextCommand):
                 project_data["settings"] = {}
             project_data["settings"]["rsync_ssh"] = {}
             project_data["settings"]["rsync_ssh"]["sync_on_save"] = True
+            project_data["settings"]["rsync_ssh"]["sync_all_on_save"] = False
             project_data["settings"]["rsync_ssh"]["excludes"] = [
                 ".git*",
                 "_build",
@@ -274,8 +275,12 @@ class RsyncSshSaveCommand(sublime_plugin.EventListener):
         # Block other instances of the same file from initiating sync (e.g. files open in more than one view)
         view.set_status("00000_rsync_ssh_status", "Sync initiated")
 
+        options = {}
+        if not settings.get("sync_all_on_save", False):
+            options["path_being_saved"] = view.file_name()
+
         # Execute sync with the name of file being saved
-        view.run_command("rsync_ssh_sync", {"path_being_saved": view.file_name()})
+        view.run_command("rsync_ssh_sync", options)
 
 
 class RsyncSshSyncCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
I prefer to always sync everything, because I do changes outside of Sublime (switchin branches, touch stuff, calling tools) outside of Sublime.

I'd like to not having to remember using a separate hotkey, I just "cmd-s" any file in the project and would it like to always sync the project consistently. It's usually quite fast anyway.

(There's another change coming up that will reduce latency further.)