### PR TITLE
Add sample and documentation for `ssh_args` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ When you initialize your project via `Initialize Settings` the plugin will add t
         // This is the block the plugin adds to your project file
         "rsync_ssh":
         {
-            // To use non-standard ssh specify the path here
+            // To use non-standard ssh specify the path here ...
             "ssh_binary": "/usr/local/bin/ssh",
+            // ... and additional arguments here
+            "ssh_args": ["-F", "~/another/config/file"],
 
             // To disable sync on save set 'sync_on_save' to false
             "sync_on_save": true,

--- a/rsync_ssh.py
+++ b/rsync_ssh.py
@@ -90,6 +90,7 @@ class RsyncSshInitSettingsCommand(sublime_plugin.TextCommand):
                 project_data["settings"] = {}
             project_data["settings"]["rsync_ssh"] = {}
             project_data["settings"]["rsync_ssh"]["sync_on_save"] = True
+            project_data["settings"]["rsync_ssh"]["ssh_args"] = []
             project_data["settings"]["rsync_ssh"]["excludes"] = [
                 ".git*",
                 "_build",


### PR DESCRIPTION
I introduced custom ssh args previous but forgot to include it in the docs and the sample config.