### PR TITLE
Fix crash on current sublime

### DIFF
--- a/rsync_ssh.py
+++ b/rsync_ssh.py
@@ -22,8 +22,10 @@ def console_print(host, prefix, output):
     print(output)
 
 
-def console_show(window=sublime.active_window()):
+def console_show(window=None):
     """Show console panel"""
+    if window is None:
+        sublime.active_window()
     window.run_command("show_panel", {"panel": "console", "toggle": False})
 
 


### PR DESCRIPTION
I've seen the plugin crash today:

```
reloading python 3.3 plugin sublime-rsync-ssh.rsync_ssh Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/Lib/python33/sublime_plugin.py", line 308, in reload_plugin
    m = importlib.import_module(modulename)
  File "./python3.3/importlib/__init__.py", line 90, in import_module
  File "<frozen importlib._bootstrap>", line 1584, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1565, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1532, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 584, in _check_name_wrapper
  File "<frozen importlib._bootstrap>", line 1022, in load_module
  File "<frozen importlib._bootstrap>", line 1003, in load_module
  File "<frozen importlib._bootstrap>", line 560, in module_for_loader_wrapper
  File "<frozen importlib._bootstrap>", line 868, in _load_module
  File "<frozen importlib._bootstrap>", line 313, in _call_with_frames_removed
  File "/Users/ctheune/Library/Application Support/Sublime Text 3/Packages/sublime-rsync-ssh/rsync_ssh.py", line 27, in <module>
    def console_show(window=sublime.active_window()):
  File "/Applications/Sublime Text.app/Contents/MacOS/Lib/python33/sublime.py", line 515, in active_window
    return Window(sublime_api.active_window())
RuntimeError: API is not available
```

This fixes it.